### PR TITLE
Keyboard support + styling edits + bugfix for modal height

### DIFF
--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -1,5 +1,5 @@
 import { Deck } from '@/types/deck';
-import { router, useForm, usePage } from '@inertiajs/react';
+import { useForm, usePage } from '@inertiajs/react';
 import { FormEvent, useState } from 'react';
 import { CardDataType } from '../types/mtg';
 import Button from './Button';
@@ -163,7 +163,7 @@ const DeckModalContent = ({
     };
 
     return (
-        <div className="flex items-center justify-between pt-2">
+        <div className="flex h-full pt-2">
             <div className="flex w-full grow flex-col items-center gap-4 py-4">
                 {isEditing ? (
                     <form
@@ -200,7 +200,7 @@ const DeckModalContent = ({
                     processing={processing}
                     removeAction={removeCard}
                 />
-                <div className="shrink-0">
+                <div className="absolute bottom-4 shrink-0">
                     {creating ? (
                         <Button
                             onClick={(e) => {

--- a/resources/js/Components/Modal.tsx
+++ b/resources/js/Components/Modal.tsx
@@ -61,16 +61,18 @@ export default function Modal({
                     leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                 >
                     <DialogPanel
-                        className={`mb-6 w-full transform overflow-visible rounded-lg bg-white shadow-xl transition-all sm:mx-auto sm:w-full dark:bg-gray-800 dark:text-white ${maxWidthClass}`}
+                        className={`mb-6 w-full transform overflow-hidden rounded-lg bg-white shadow-xl transition-all sm:mx-auto sm:w-full dark:bg-gray-800 dark:text-white ${maxWidthClass}`}
                     >
-                        <div className="bg-zinc-900 px-4 pb-6 pt-11">
+                        <div className="relative flex h-[80vh] flex-col bg-zinc-900 px-4 pb-6 pt-11">
                             <button
                                 onClick={close}
                                 className="absolute right-0 top-0 p-2 text-2xl text-zinc-900 hover:text-zinc-100 focus:outline-none focus:ring-4 focus:ring-zinc-200 dark:text-zinc-200 dark:hover:text-zinc-500"
                             >
                                 <IoIosClose />
                             </button>
-                            <>{children}</>
+                            <div className="flex-grow overflow-auto">
+                                <>{children}</>
+                            </div>
                         </div>
                     </DialogPanel>
                 </TransitionChild>

--- a/resources/js/Components/Searchbar.tsx
+++ b/resources/js/Components/Searchbar.tsx
@@ -29,10 +29,21 @@ const Searchbar = ({
     );
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | undefined>(undefined);
+    const [highlightedIndex, setHighlightedIndex] = useState<number | null>(
+        null,
+    );
 
     const searchWrapperRef = useRef(null);
+    const listRef = useRef<HTMLUListElement | null>(null);
+
     const handleOutsideClick = () => {
+        resetSearch();
+    };
+
+    const resetSearch = () => {
+        setUserSearchInput('');
         setAutoCompleteResults([]);
+        setHighlightedIndex(null);
         setError(undefined);
     };
     useOutsideAlerter(searchWrapperRef, () => handleOutsideClick());
@@ -57,6 +68,7 @@ const Searchbar = ({
         setUserSearchInput(searchQuery);
         if (!validateSearch(searchQuery)) {
             setLoading(false);
+            console.error('Search query is invalid', searchQuery);
             throw new Error(error);
         }
         try {
@@ -78,7 +90,7 @@ const Searchbar = ({
                 ? await scryfallNamedSearch(searchQuery)
                 : await scryfallSearch(searchQuery);
             const output: CardDataType[] = await prepCardDataForRender([data]);
-            setAutoCompleteResults([]);
+            resetSearch();
             parentSetter(output);
         } catch (error) {
             console.error(error);
@@ -92,13 +104,24 @@ const Searchbar = ({
         setLoading(true);
 
         try {
-            handleSubmitSearch(searchQuery);
-            setAutoCompleteResults([]);
+            await handleSubmitSearch(searchQuery);
             setLoading(false);
         } catch (error) {
             console.error(error);
         } finally {
             setLoading(false);
+        }
+    };
+
+    const scrollToHighlightedIndex = (index: number | null) => {
+        if (listRef.current && index !== null) {
+            const listItem = listRef.current.children[index] as HTMLElement;
+            if (listItem) {
+                listItem.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'nearest',
+                });
+            }
         }
     };
 
@@ -127,12 +150,67 @@ const Searchbar = ({
                 <input
                     type="search"
                     id="default-search"
-                    className="block w-full rounded-lg border border-zinc-300 bg-zinc-50 p-4 ps-10 text-sm text-zinc-900 focus:border-zinc-500 focus:ring-blue-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-white dark:placeholder-zinc-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+                    className={`block w-full ${autoCompleteResults.length > 0 ? 'rounded-t-lg' : 'rounded-lg'} border border-zinc-300 bg-zinc-50 p-4 ps-10 text-sm text-zinc-900 focus:border-zinc-500 focus:ring-blue-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-white dark:placeholder-zinc-400 dark:focus:border-blue-500 dark:focus:ring-blue-500`}
                     placeholder={placeholderText ?? `Search for a card`}
                     min={3}
                     max={100}
                     value={userSearchInput}
                     onChange={(e) => handleSearchOnChange(e.target.value)}
+                    onKeyDown={(e) => {
+                        let newIndex = highlightedIndex;
+                        switch (e.key) {
+                            case 'Enter':
+                                e.preventDefault();
+                                handleSubmitSearch(
+                                    !highlightedIndex
+                                        ? userSearchInput
+                                        : autoCompleteResults[highlightedIndex],
+                                );
+                                break;
+                            case 'Escape':
+                                setUserSearchInput('');
+                                setAutoCompleteResults([]);
+                                break;
+                            case 'ArrowUp':
+                                e.preventDefault();
+                                if (highlightedIndex !== null) {
+                                    newIndex =
+                                        highlightedIndex > 0
+                                            ? highlightedIndex - 1
+                                            : autoCompleteResults.length - 1;
+                                    setHighlightedIndex(newIndex);
+                                    scrollToHighlightedIndex(newIndex);
+                                }
+                                break;
+                            case 'ArrowDown':
+                                e.preventDefault();
+                                newIndex =
+                                    highlightedIndex !== null &&
+                                    highlightedIndex <
+                                        autoCompleteResults.length - 1
+                                        ? highlightedIndex + 1
+                                        : 0;
+                                setHighlightedIndex(newIndex);
+                                scrollToHighlightedIndex(newIndex);
+                                break;
+                            case 'Tab':
+                                if (autoCompleteResults.length > 0) {
+                                    e.preventDefault();
+
+                                    setUserSearchInput(
+                                        autoCompleteResults[
+                                            highlightedIndex ?? 0
+                                        ],
+                                    );
+                                    !highlightedIndex
+                                        ? setHighlightedIndex(0)
+                                        : setHighlightedIndex(null);
+                                }
+                                break;
+                            default:
+                                break;
+                        }
+                    }}
                     autoFocus={autofocus}
                     autoComplete="off"
                 />
@@ -145,19 +223,30 @@ const Searchbar = ({
             </div>
 
             <div
-                className={`autocomplete-results ${autoCompleteResults.length > 0 ? 'block' : 'hidden'}`}
-                style={{ position: 'relative', zIndex: 10 }}
+                className={`autocomplete-results rounded-b-lg border border-zinc-300 dark:border-zinc-600 ${
+                    autoCompleteResults.length > 0 ? 'block' : 'hidden'
+                }`}
+                style={{
+                    position: 'relative',
+                    zIndex: 10,
+                    maxHeight: '20vh',
+                    overflowY: 'auto',
+                }}
             >
                 <ul
-                    className="z-99 max-h-[20vh] w-auto overflow-y-auto rounded-lg border border-zinc-300 bg-zinc-700/90 py-2 dark:border-zinc-600"
+                    ref={listRef}
+                    className="autocomplete-results-list z-99 relative w-auto rounded-b-lg bg-zinc-800/50"
                     tabIndex={0}
                 >
+                    <div className="sticky top-0 z-10 h-1 py-2 shadow-[inset_0_4px_6px_rgba(0,0,0,0.5)]"></div>
                     {autoCompleteResults.map(
                         (result: string, index: number) => (
                             <li
-                                className={
-                                    'cursor-pointer px-2 hover:bg-zinc-200 hover:text-zinc-800'
-                                }
+                                className={`cursor-pointer px-2 ${
+                                    highlightedIndex === index
+                                        ? 'bg-zinc-200 text-zinc-800'
+                                        : 'hover:bg-zinc-400 hover:text-zinc-800'
+                                }`}
                                 key={`autoCompleteResults-${index}`}
                                 onClick={() =>
                                     handleAutoCompleteResultClick(result)


### PR DESCRIPTION
no video - Best to pull down and test keyboard search on your own

- when typing in search bar:
  - up/down keys will scroll and highlight from autocomplete results
  - tab/enter will autocomplete with the highlighted autocomplete result. if no highlight then it will autocomplete to first index of results
- bug fix for modal height shift on searchbar interaction by making modal height fixed again - need input from @nickzou 
- better styling for autocomplete results + differentiation between hover and highlighted result