### PR TITLE
114 update user flow after add card to multiple decks to bounce back to card pool view with new card in place

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -152,7 +152,9 @@ class DeckController extends Controller
                 return response()->json(['message' => 'Decks updated successfully']);
             }
 
-            return redirect(route('decks.index'))->with('success', 'Decks updated successfully');
+            return redirect(route('cards.index'))->with([
+                'success' => 'Decks updated successfully!',
+            ]);
         } catch (\Exception $e) {
             // Rollback the transaction on error
             DB::rollBack();

--- a/resources/js/Components/AddCardModalContent.tsx
+++ b/resources/js/Components/AddCardModalContent.tsx
@@ -2,7 +2,7 @@ import { Deck } from '@/types/deck';
 import { CardDataType } from '@/types/mtg';
 import updateDecks from '@/utilities/updateDecks';
 import { usePage } from '@inertiajs/react';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import useBreakpoint from 'use-breakpoint';
 import Button from './Button';
 import LabeledCheckbox from './LabeledCheckbox';
@@ -13,9 +13,10 @@ import Searchbar from './Searchbar';
 type Props = {
     decks: Deck[];
     cardpool?: CardDataType[];
+    modalClose?: Dispatch<SetStateAction<boolean>>;
 };
 
-const AddCardModalContent = ({ decks, cardpool }: Props) => {
+const AddCardModalContent = ({ decks, cardpool, modalClose }: Props) => {
     const BREAKPOINTS = { sm: 640, md: 768, lg: 1024, xl: 1280, '2xl': 1536 };
     const { auth } = usePage().props;
     const [searchFocus, setSearchFocus] = useState<boolean>(true);
@@ -31,9 +32,12 @@ const AddCardModalContent = ({ decks, cardpool }: Props) => {
         setSearchFocus(false);
     };
     useEffect(() => {
-        console.log(`max: ${maxWidth}`);
-        console.log(`min: ${minWidth}`);
-    });
+        if (submitted === true) {
+            if (modalClose !== undefined) {
+                modalClose(false);
+            }
+        }
+    }, [submitted]);
     const handleDeckSelect = (deck: Deck) => {
         if (selectedDecks.length === 0) {
             setSelectedDecks([deck]);

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -42,7 +42,7 @@ export default function Cards({ cards, decks }: { cards: any; decks: Deck[] }) {
                 </div>
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                     {parsedCardsWithDeckRefs.length > 0 &&
-                        parsedCardsWithDeckRefs.map((card: CardsWithDecks) => (
+                        parsedCardsWithDeckRefs.sort((a,b) => a.name.localeCompare(b.name)).map((card: CardsWithDecks) => (
                             <div key={`${card.id}`}>
                                 <MTGCard
                                     id={card.id}

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -64,7 +64,7 @@ export default function Cards({ cards, decks }: { cards: any; decks: Deck[] }) {
             </div>
             {isAdding && (
                 <Modal show={true} onClose={() => setIsAdding(false)}>
-                    <AddCardModalContent decks={decks} cardpool={cards} />
+                    <AddCardModalContent decks={decks} cardpool={cards} modalClose={setIsAdding} />
                 </Modal>
             )}
         </AuthenticatedLayout>


### PR DESCRIPTION
-redirect to `cards.index` after successful card submission
-closes modal upon successful submission
-sort `CardPool` alphabetically