### PR TITLE
various bug fixes and tweaks to deck modal

### DIFF
--- a/resources/js/Components/ButtonLink.tsx
+++ b/resources/js/Components/ButtonLink.tsx
@@ -1,13 +1,18 @@
 import { ComponentProps } from 'react';
 
 type Props = ComponentProps<'a'>;
-const ButtonLink = ({ children, ...props }: Props) => {
+const ButtonLink = ({
+    children,
+    disabled,
+    ...props
+}: Props & { disabled?: boolean }) => {
     return (
         <a
             {...props}
-            className={
-                'btn bg-lg rounded-md border border-solid border-slate-600 px-3 py-2 disabled:opacity-25'
-            }
+            className={`btn bg-lg rounded-md border border-solid border-slate-600 px-3 py-2 ${
+                disabled ? 'pointer-events-none opacity-25' : ''
+            }`}
+            onClick={(e) => disabled && e.preventDefault()}
         >
             {children}
         </a>

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -32,7 +32,9 @@ const DeckCardSearch = ({
                 !searchingForCommanders &&
                 !commanderColorIdentity.some((color) =>
                     card.colorIdentity?.includes(color),
-                );
+                ) &&
+                card.colorIdentity !== undefined &&
+                card.colorIdentity.length > 0;
             return { ...card, isInvalidColor };
         });
     }, [cards, commanderColorIdentity]);

--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -339,6 +339,7 @@ const DeckModalContent = ({
                                 e.preventDefault(); // Prevent default button behavior
                                 onSubmit(e); // Trigger the form submission
                             }}
+                            disabled={processing || disableSubmitButton}
                         >
                             Create Deck
                         </Button>
@@ -366,10 +367,15 @@ const DeckModalContent = ({
                             <Button
                                 disabled={processing || disableSubmitButton}
                                 onClick={(e) => {
-                                    e.preventDefault(); // Prevent default navigation
-                                    onSubmit(e, () => {
+                                    // TO DO : refactor to use link
+                                    if (isEditing) {
+                                        e.preventDefault(); // Prevent default navigation
+                                        onSubmit(e, () => {
+                                            window.location.href = `/decks/${deck?.id}`; // Navigate to the href
+                                        }); // Wait for onSubmit to resolve
+                                    } else {
                                         window.location.href = `/decks/${deck?.id}`; // Navigate to the href
-                                    }); // Wait for onSubmit to resolve
+                                    }
                                 }}
                             >
                                 deck details

--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -3,7 +3,6 @@ import { getColorIdentityFromCommanders } from '@/utilities/general';
 import { useForm, usePage } from '@inertiajs/react';
 import { FormEvent, useEffect, useState } from 'react';
 import Button from './Button';
-import ButtonLink from './ButtonLink';
 import DeckCardSearch from './DeckCardSearch';
 import Input from './Input';
 import { useToast } from './Toast/ToastContext';
@@ -209,7 +208,7 @@ const DeckModalContent = ({
         onClose();
     };
 
-    const onSubmit = (e: FormEvent) => {
+    const onSubmit = (e: FormEvent, callback?: () => void) => {
         e.preventDefault();
         validate();
         if (errors.name || errors.cards || errors.commanders) {
@@ -234,6 +233,9 @@ const DeckModalContent = ({
                                 `Deck "${response.props.updatedDeck.name}" created`,
                                 'info',
                             );
+                        }
+                        if (callback) {
+                            callback();
                         }
                     } else {
                         console.warn(
@@ -261,6 +263,9 @@ const DeckModalContent = ({
                             `Deck "${response.props.updatedDeck.name}" updated`,
                             'info',
                         );
+                        if (callback) {
+                            callback();
+                        }
                     } else {
                         console.warn(
                             'Invalid or empty updatedDeck:',
@@ -358,16 +363,17 @@ const DeckModalContent = ({
                                     Save
                                 </Button>
                             )}
-                            <ButtonLink
-                                href={`/decks/${deck?.id}`}
+                            <Button
                                 disabled={processing || disableSubmitButton}
                                 onClick={(e) => {
-                                    e.preventDefault();
-                                    onSubmit(e);
+                                    e.preventDefault(); // Prevent default navigation
+                                    onSubmit(e, () => {
+                                        window.location.href = `/decks/${deck?.id}`; // Navigate to the href
+                                    }); // Wait for onSubmit to resolve
                                 }}
                             >
                                 deck details
-                            </ButtonLink>
+                            </Button>
                         </div>
                     )}
                 </div>

--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -126,16 +126,22 @@ const DeckModalContent = ({
     };
 
     useEffect(() => {
-        const allColorsFromCards = selectedCards.flatMap(
-            (card) => card.colorIdentity,
+        const allUniqueColorsFromCards = Array.from(
+            new Set(selectedCards.flatMap((card) => card.colorIdentity)),
         );
-        const invalidColorIdentity = !currentColorIdentity
-            .filter((color): color is mtgColorStrings => color !== undefined)
-            .some((color: mtgColorStrings) =>
-                allColorsFromCards.includes(color),
-            );
+        const areAnyCardColorsInvalid = allUniqueColorsFromCards.some(
+            (color) => !currentColorIdentity.includes(color),
+        );
+        const invalidColorIdentity =
+            allUniqueColorsFromCards.length > 0
+                ? areAnyCardColorsInvalid
+                : false;
 
-        if (invalidColorIdentity) {
+        if (
+            invalidColorIdentity &&
+            (isFormEdited || isEditing) &&
+            selectedCards.length > 0
+        ) {
             setError(
                 'cards',
                 "Selected cards do not match the deck's color identity",
@@ -143,7 +149,7 @@ const DeckModalContent = ({
         } else {
             clearErrors('cards');
         }
-    }, [selectedCards, currentColorIdentity]);
+    }, [selectedCards, currentColorIdentity, isEditing]);
 
     useEffect(() => {
         if (errors.name || errors.cards || errors.commanders) {
@@ -352,7 +358,14 @@ const DeckModalContent = ({
                                     Save
                                 </Button>
                             )}
-                            <ButtonLink href={`/decks/${deck?.id}`}>
+                            <ButtonLink
+                                href={`/decks/${deck?.id}`}
+                                disabled={processing || disableSubmitButton}
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    onSubmit(e);
+                                }}
+                            >
                                 deck details
                             </ButtonLink>
                         </div>

--- a/resources/js/Components/Searchbar.tsx
+++ b/resources/js/Components/Searchbar.tsx
@@ -172,6 +172,14 @@ const Searchbar = ({
                         switch (e.key) {
                             case 'Enter':
                                 e.preventDefault();
+
+                                setUserSearchInput(
+                                    autoCompleteResults[highlightedIndex ?? 0],
+                                );
+                                !highlightedIndex
+                                    ? setHighlightedIndex(0)
+                                    : setHighlightedIndex(null);
+
                                 handleSubmitSearch(
                                     !highlightedIndex
                                         ? userSearchInput

--- a/resources/js/Pages/Decks/Index.tsx
+++ b/resources/js/Pages/Decks/Index.tsx
@@ -148,11 +148,11 @@ export default function Decks({ decks, updatedDeck }: DecksProps) {
                     deck.id === updatedDeck.id ? updatedDeck : deck,
                 );
             } else {
-                // Append the new deck if it doesn't exist
+                // prepend the new deck if it doesn't exist
                 console.warn(
                     `Deck with id ${updatedDeck.id} not found. Appending to decksToDisplay.`,
                 );
-                return [...prevDecks, updatedDeck];
+                return [updatedDeck, ...prevDecks];
             }
         });
     };


### PR DESCRIPTION
- color validation logic fix: colorless cards are no longer invalid
- color validation logic fix: unable to submit if even one card is invalid
- deck details btn: disabled if invalid
- deck details btn: will submit edits before navigation
- new decks are now prepended to deck list instead of appended
- searchbar: 'enter' on highlighted search result will now autocomplete before submission
- color validation error will now only appear is in editing mode or if form is dirty
- 
