### PR TITLE
Refactor DeckCardSearch component

### DIFF
--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -9,7 +9,7 @@ type Props = {
     cards: CardDataType[];
     processing: boolean;
     removeAction: (card: CardDataType) => void;
-    searchingForCommanders: boolean;
+    colorValidation?: boolean;
     commanderColorIdentity: mtgColorStrings[];
 };
 
@@ -23,13 +23,13 @@ const DeckCardSearch = ({
     cards,
     processing,
     removeAction,
-    searchingForCommanders,
+    colorValidation = false,
     commanderColorIdentity,
 }: Props) => {
     const validateCardColors = useCallback(() => {
         return cards.map((card) => {
             const isInvalidColor =
-                !searchingForCommanders &&
+                colorValidation &&
                 !commanderColorIdentity.some((color) =>
                     card.colorIdentity?.includes(color),
                 ) &&
@@ -46,16 +46,9 @@ const DeckCardSearch = ({
                     autofocus={false}
                     parentSetter={parentSetter}
                     specificCard
-                    CTAText={
-                        searchingForCommanders ? 'Add Commander' : 'Add Card'
-                    }
-                    placeholderText={
-                        searchingForCommanders
-                            ? 'Add commanders to your deck'
-                            : 'Add cards to your deck'
-                    }
+                    CTAText={'Add Card'}
+                    placeholderText={'Add cards to your deck'}
                     cardsToExclude={cards}
-                    searchingForCommanders={searchingForCommanders}
                 ></Searchbar>
             )}
 

--- a/resources/js/Components/DeckCommanderSearch.tsx
+++ b/resources/js/Components/DeckCommanderSearch.tsx
@@ -1,0 +1,71 @@
+
+import { CardDataType, mtgColorStrings } from '@/types/mtg';
+import { useCallback } from 'react';
+import NametagButton from './NametagButton';
+import Searchbar from './Searchbar';
+
+type Props = {
+    isSearching: boolean;
+    parentSetter: (value: CardDataType[] | []) => void;
+    cards: CardDataType[];
+    processing: boolean;
+    removeAction: (card: CardDataType) => void;
+    commanderColorIdentity: mtgColorStrings[];
+};
+
+type CardDataTypeWithInvalidColor = CardDataType & {
+    isInvalidColor: boolean;
+};
+
+const DeckCommanderSearch = ({
+    isSearching,
+    parentSetter,
+    cards,
+    processing,
+    removeAction,
+    commanderColorIdentity,
+}: Props) => {
+    return (
+        <>
+            {isSearching && (
+                <Searchbar
+                    autofocus={false}
+                    parentSetter={parentSetter}
+                    specificCard
+                    CTAText={
+                        'Add Commander'                   }
+                    placeholderText={
+                        'Add commanders to your deck'
+                    }
+                    cardsToExclude={cards}
+                ></Searchbar>
+            )}
+
+            {cards.length > 0 && (
+                <>
+                    <ul className="flex max-h-[30vh] w-full flex-wrap overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2">
+                        {cards.map((card) => {
+                            return (
+                                <li
+                                    key={`selectedcard-${card.id}`}
+                                    className="m-1"
+                                >
+                                    <NametagButton
+                                        aria-label={`remove ${card.name} from deck`}
+                                        disabled={processing || !isSearching}
+                                        onClick={() => removeAction(card)}
+                                        showClose={processing || isSearching}
+                                    >
+                                        {card.name}
+                                    </NametagButton>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </>
+            )}
+        </>
+    );
+};
+
+export default DeckCommanderSearch;

--- a/resources/js/Components/DeckCommanderSearch.tsx
+++ b/resources/js/Components/DeckCommanderSearch.tsx
@@ -1,6 +1,4 @@
-
 import { CardDataType, mtgColorStrings } from '@/types/mtg';
-import { useCallback } from 'react';
 import NametagButton from './NametagButton';
 import Searchbar from './Searchbar';
 
@@ -32,11 +30,8 @@ const DeckCommanderSearch = ({
                     autofocus={false}
                     parentSetter={parentSetter}
                     specificCard
-                    CTAText={
-                        'Add Commander'                   }
-                    placeholderText={
-                        'Add commanders to your deck'
-                    }
+                    CTAText={'Add Commander'}
+                    placeholderText={'Add commanders to your deck'}
                     cardsToExclude={cards}
                 ></Searchbar>
             )}

--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -4,6 +4,7 @@ import { useForm, usePage } from '@inertiajs/react';
 import { FormEvent, useEffect, useState } from 'react';
 import Button from './Button';
 import DeckCardSearch from './DeckCardSearch';
+import DeckCommanderSearch from './DeckCommanderSearch';
 import Input from './Input';
 import { useToast } from './Toast/ToastContext';
 
@@ -314,13 +315,12 @@ const DeckModalContent = ({
                         )}
                     </div>
                 )}
-                <DeckCardSearch
+                <DeckCommanderSearch
                     isSearching={isEditing}
                     parentSetter={handleCommanderSelect}
                     cards={selectedCommanders}
                     processing={processing}
                     removeAction={removeCommander}
-                    searchingForCommanders={true}
                     commanderColorIdentity={currentColorIdentity}
                 />
                 <DeckCardSearch
@@ -329,7 +329,7 @@ const DeckModalContent = ({
                     cards={selectedCards}
                     processing={processing}
                     removeAction={removeCard}
-                    searchingForCommanders={false}
+                    colorValidation={true}
                     commanderColorIdentity={currentColorIdentity}
                 />
                 <div className="absolute bottom-4 shrink-0">

--- a/resources/js/Components/NametagButton.tsx
+++ b/resources/js/Components/NametagButton.tsx
@@ -9,7 +9,7 @@ type Props = ComponentProps<'button'> & {
 const NametagButton = ({
     'aria-label': ariaLabel,
     disabled,
-    invalid=false,
+    invalid = false,
     onClick,
     children,
     showClose = false,

--- a/resources/js/Components/NametagButton.tsx
+++ b/resources/js/Components/NametagButton.tsx
@@ -3,13 +3,13 @@ import { IoIosClose } from 'react-icons/io';
 
 type Props = ComponentProps<'button'> & {
     showClose: boolean;
-    invalid: boolean;
+    invalid?: boolean;
 };
 
 const NametagButton = ({
     'aria-label': ariaLabel,
     disabled,
-    invalid,
+    invalid=false,
     onClick,
     children,
     showClose = false,

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -1,7 +1,10 @@
 import CardList from '@/Components/CardList';
 import { useToast } from '@/Components/Toast/ToastContext';
 import { CardDataType, CardsWithDecks, Deck as DeckProps } from '@/types/mtg';
-import updateDecks, { removeCard, removeCommander } from '@/utilities/updateDecks';
+import updateDecks, {
+    removeCard,
+    removeCommander,
+} from '@/utilities/updateDecks';
 import { usePage } from '@inertiajs/react';
 
 type Props = {

--- a/resources/js/utilities/updateDecks.ts
+++ b/resources/js/utilities/updateDecks.ts
@@ -10,11 +10,17 @@ export const removeCard = (deck: Deck, card: CardDataType | CardsWithDecks) => {
     return deck.cards.filter((c) => c.id !== card.id);
 };
 
-export const addCommander = (deck: Deck, card: CardDataType | CardsWithDecks) => {
+export const addCommander = (
+    deck: Deck,
+    card: CardDataType | CardsWithDecks,
+) => {
     return [...deck.commanders, card];
 };
 
-export const removeCommander = (deck: Deck, card: CardDataType | CardsWithDecks) => {
+export const removeCommander = (
+    deck: Deck,
+    card: CardDataType | CardsWithDecks,
+) => {
     return deck.commanders.filter((c) => c.id !== card.id);
 };
 type UpdateDecks = {
@@ -34,7 +40,7 @@ const updateDecks = (args: UpdateDecks) => {
         cards: !!cards ? cards : deck.cards,
         commanders: !!commanders ? commanders : deck.commanders,
     }));
-    console.log(updatedDecks)
+    console.log(updatedDecks);
     router.put(
         route('decks.update-batch'),
         { user_id: user_id, decks: updatedDecks },


### PR DESCRIPTION
I think the `DeckCardSearch` component is doing too much as is. Currently is has the responsibility of handling the deck card search but also the commander card search. The internal logic is growing ever more complex as the conditions for checking if the we are searching for a commander as opposed to a regular cards start to deviate. I imagine this will become only more complex as we start adding game rules to the search (standard Commander rules vs custom Commander lists). I think it is prudent to refactor this component into two: `DeckCardSearch` and `DeckCommanderSearch` components. In essence, these are both just wrapper components for `Searchbar` and are functionally just local Context Providers.