### PR TITLE
Deckshow refactor

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,15 @@
 ## Description
 <!-- Provide a brief summary of your changes -->
+ - 
 
-
-## Testing Performed or How to Test
+## How to Test
 <!-- Describe what testing you've done -->
  - [ ] 
 
 
 ## Screenshots (if applicable)
 <!-- Add screenshots here if there are UI changes -->
+
+## To Do
+<!-- Describe what testing you've done -->
+ - 

--- a/resources/js/Components/CardList.tsx
+++ b/resources/js/Components/CardList.tsx
@@ -1,13 +1,19 @@
-import { CardDataType, CardWithDecks } from '@/types/mtg';
+import { CardDataType, CardWithDecksType } from '@/types/mtg';
 import { isCardWithDecks } from '@/utilities/general';
 import MTGCard from './MTGCard';
 
 type Props = {
-    cards: CardWithDecks[] | CardDataType[];
+    cards: CardWithDecksType[] | CardDataType[];
     showDecks?: boolean;
-    parentDelete?: (card: CardDataType | CardWithDecks) => void | null;
+    parentDelete?: (card: CardDataType | CardWithDecksType) => void | null;
+    deleteDisabled?: boolean;
 };
-const CardList = ({ cards, showDecks = false, parentDelete }: Props) => {
+const CardList = ({
+    cards,
+    showDecks = false,
+    parentDelete,
+    deleteDisabled,
+}: Props) => {
     return (
         <>
             {cards
@@ -25,9 +31,13 @@ const CardList = ({ cards, showDecks = false, parentDelete }: Props) => {
                             power={card.power}
                             toughness={card.toughness}
                             backCardData={card.backCardData}
-                            onDelete={() => {
-                                if (parentDelete) parentDelete(card);
-                            }}
+                            onDelete={
+                                deleteDisabled
+                                    ? undefined
+                                    : () => {
+                                          if (parentDelete) parentDelete(card);
+                                      }
+                            }
                             decks={
                                 showDecks && isCardWithDecks(card)
                                     ? card.decks

--- a/resources/js/Components/CardList.tsx
+++ b/resources/js/Components/CardList.tsx
@@ -7,19 +7,28 @@ type Props = {
     showDecks?: boolean;
     parentDelete?: (card: CardDataType | CardWithDecksType) => void | null;
     deleteDisabled?: boolean;
+    invalidCards?: string[];
 };
 const CardList = ({
     cards,
     showDecks = false,
     parentDelete,
     deleteDisabled,
+    invalidCards,
 }: Props) => {
     return (
         <>
             {cards
                 .sort((a, b) => a.name.localeCompare(b.name))
                 .map((card) => (
-                    <div key={`${card.id}`}>
+                    <div
+                        key={`${card.id}`}
+                        className={
+                            invalidCards?.includes(card.id)
+                                ? 'rounded-mtg border border-2 border-red-800'
+                                : ''
+                        }
+                    >
                         <MTGCard
                             id={card.id}
                             imgUris={card.imgUris}
@@ -32,7 +41,8 @@ const CardList = ({
                             toughness={card.toughness}
                             backCardData={card.backCardData}
                             onDelete={
-                                deleteDisabled
+                                deleteDisabled &&
+                                !invalidCards?.includes(card.id)
                                     ? undefined
                                     : () => {
                                           if (parentDelete) parentDelete(card);

--- a/resources/js/Components/CardList.tsx
+++ b/resources/js/Components/CardList.tsx
@@ -16,6 +16,13 @@ const CardList = ({
     deleteDisabled,
     invalidCards,
 }: Props) => {
+    const handleDelete = (card: CardWithDecksType | CardDataType) => {
+        if (deleteDisabled && !invalidCards?.includes(card.id)) {
+            return undefined;
+        } else {
+            if (parentDelete) parentDelete(card);
+        }
+    };
     return (
         <>
             {cards
@@ -25,7 +32,7 @@ const CardList = ({
                         key={`${card.id}`}
                         className={
                             invalidCards?.includes(card.id)
-                                ? 'rounded-mtg border border-2 border-red-800'
+                                ? 'rounded-mtg border border-2 border-solid border-red-800'
                                 : ''
                         }
                     >
@@ -40,14 +47,7 @@ const CardList = ({
                             power={card.power}
                             toughness={card.toughness}
                             backCardData={card.backCardData}
-                            onDelete={
-                                deleteDisabled &&
-                                !invalidCards?.includes(card.id)
-                                    ? undefined
-                                    : () => {
-                                          if (parentDelete) parentDelete(card);
-                                      }
-                            }
+                            onDelete={() => handleDelete(card)}
                             decks={
                                 showDecks && isCardWithDecks(card)
                                     ? card.decks

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -76,12 +76,15 @@ const DeckCardSearch = ({
                     })}
                 </ul>
             )}
-            {cardVisualization && cardsToDisplay.length > 0 && (
+            {cardVisualization && cards.length > 0 && (
                 <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
                     <CardList
-                        cards={cardsToDisplay}
+                        cards={cards}
                         parentDelete={removeAction}
                         deleteDisabled={processing || !isSearching}
+                        invalidCards={cardsToDisplay.flatMap((card) =>
+                            card.isInvalidColor ? [card.id] : [],
+                        )}
                     />
                 </div>
             )}

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -1,5 +1,6 @@
 import { CardDataType, mtgColorStrings } from '@/types/mtg';
 import { useCallback } from 'react';
+import CardList from './CardList';
 import NametagButton from './NametagButton';
 import Searchbar from './Searchbar';
 
@@ -11,6 +12,7 @@ type Props = {
     removeAction: (card: CardDataType) => void;
     colorValidation?: boolean;
     commanderColorIdentity: mtgColorStrings[];
+    cardVisualization?: boolean;
 };
 
 const DeckCardSearch = ({
@@ -21,6 +23,7 @@ const DeckCardSearch = ({
     removeAction,
     colorValidation = false,
     commanderColorIdentity,
+    cardVisualization = false,
 }: Props) => {
     const validateCardColors = useCallback(() => {
         if (!colorValidation) return cards;
@@ -53,7 +56,7 @@ const DeckCardSearch = ({
                 </div>
             )}
 
-            {cardsToDisplay.length > 0 && (
+            {!cardVisualization && cardsToDisplay.length > 0 && (
                 <ul className="z-0 flex max-h-[30vh] min-h-[3.6rem] w-full flex-wrap overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2">
                     {cardsToDisplay.map((card) => {
                         return (
@@ -71,6 +74,14 @@ const DeckCardSearch = ({
                         );
                     })}
                 </ul>
+            )}
+            {cardVisualization && cardsToDisplay.length > 0 && (
+                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4">
+                    <CardList
+                        cards={cardsToDisplay}
+                        parentDelete={removeAction}
+                    />
+                </div>
             )}
         </div>
     );

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -49,7 +49,6 @@ const DeckCardSearch = ({
                 ) ?? false;
 
             const isInvalidColor =
-                isColorlessCard ||
                 containsAnyInvalidColor ||
                 (isMissingCommanderColor && !isColorlessCard);
 

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -81,6 +81,7 @@ const DeckCardSearch = ({
                     <CardList
                         cards={cardsToDisplay}
                         parentDelete={removeAction}
+                        deleteDisabled={processing || !isSearching}
                     />
                 </div>
             )}

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -28,18 +28,40 @@ const DeckCardSearch = ({
     const validateCardColors = useCallback(() => {
         if (!colorValidation) return cards;
         return cards.map((card) => {
-            const isInvalidColor =
+            const colorIdentityArray: mtgColorStrings[] = Array.isArray(
+                card.colorIdentity,
+            )
+                ? card.colorIdentity
+                : [];
+
+            const isMissingCommanderColor =
                 colorValidation &&
                 !commanderColorIdentity.some((color) =>
-                    card.colorIdentity?.includes(color),
-                ) &&
-                card.colorIdentity !== undefined &&
-                card.colorIdentity.length > 0;
+                    colorIdentityArray.includes(color),
+                );
+
+            const isColorlessCard = colorIdentityArray.length === 0;
+
+            const containsAnyInvalidColor =
+                colorIdentityArray.some(
+                    (color: mtgColorStrings) =>
+                        !commanderColorIdentity.includes(color),
+                ) ?? false;
+
+            const isInvalidColor =
+                isColorlessCard ||
+                containsAnyInvalidColor ||
+                (isMissingCommanderColor && !isColorlessCard);
+
+            console.log(
+                `Card: ${card.name}, isInvalidColor: ${isInvalidColor}, colorIdentity: ${colorIdentityArray}, commanderColorIdentity: ${commanderColorIdentity}`,
+            );
             return { ...card, isInvalidColor };
         });
     }, [cards, commanderColorIdentity]);
 
     const cardsToDisplay = validateCardColors();
+    console.log('cardsToDisplay', cardsToDisplay);
     return (
         <div className="relative z-0 flex w-full flex-col">
             {isSearching && (

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -53,15 +53,12 @@ const DeckCardSearch = ({
                 containsAnyInvalidColor ||
                 (isMissingCommanderColor && !isColorlessCard);
 
-            console.log(
-                `Card: ${card.name}, isInvalidColor: ${isInvalidColor}, colorIdentity: ${colorIdentityArray}, commanderColorIdentity: ${commanderColorIdentity}`,
-            );
             return { ...card, isInvalidColor };
         });
     }, [cards, commanderColorIdentity]);
 
     const cardsToDisplay = validateCardColors();
-    console.log('cardsToDisplay', cardsToDisplay);
+
     return (
         <div className="relative z-0 flex w-full flex-col">
             {isSearching && (

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -38,6 +38,7 @@ const DeckCardSearch = ({
             return { ...card, isInvalidColor };
         });
     }, [cards, commanderColorIdentity]);
+
     const cardsToDisplay = validateCardColors();
     return (
         <div className="relative z-0 flex w-full flex-col">

--- a/resources/js/Components/DeckCardSearch.tsx
+++ b/resources/js/Components/DeckCardSearch.tsx
@@ -77,7 +77,7 @@ const DeckCardSearch = ({
                 </ul>
             )}
             {cardVisualization && cardsToDisplay.length > 0 && (
-                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4">
+                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
                     <CardList
                         cards={cardsToDisplay}
                         parentDelete={removeAction}

--- a/resources/js/Components/DeckCommanderSearch.tsx
+++ b/resources/js/Components/DeckCommanderSearch.tsx
@@ -1,4 +1,5 @@
 import { CardDataType, mtgColorStrings } from '@/types/mtg';
+import CardList from './CardList';
 import NametagButton from './NametagButton';
 import Searchbar from './Searchbar';
 
@@ -9,6 +10,7 @@ type Props = {
     processing: boolean;
     removeAction: (card: CardDataType) => void;
     commanderColorIdentity: mtgColorStrings[];
+    cardVisualization?: boolean;
 };
 
 const DeckCommanderSearch = ({
@@ -17,6 +19,7 @@ const DeckCommanderSearch = ({
     commanders,
     processing,
     removeAction,
+    cardVisualization,
 }: Props) => {
     return (
         <div className="relative z-0 flex w-full flex-col">
@@ -34,7 +37,7 @@ const DeckCommanderSearch = ({
                 </div>
             )}
 
-            {commanders.length > 0 && (
+            {!cardVisualization && commanders.length > 0 && (
                 <ul className="z-0 flex max-h-[30vh] min-h-[3.6rem] w-full flex-wrap overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2">
                     {commanders.map((commander) => {
                         return (
@@ -54,6 +57,11 @@ const DeckCommanderSearch = ({
                         );
                     })}
                 </ul>
+            )}
+            {cardVisualization && commanders.length > 0 && (
+                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4">
+                    <CardList cards={commanders} parentDelete={removeAction} />
+                </div>
             )}
         </div>
     );

--- a/resources/js/Components/DeckCommanderSearch.tsx
+++ b/resources/js/Components/DeckCommanderSearch.tsx
@@ -59,7 +59,7 @@ const DeckCommanderSearch = ({
                 </ul>
             )}
             {cardVisualization && commanders.length > 0 && (
-                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4">
+                <div className="z-0 grid w-full grid-cols-1 gap-4 overflow-y-auto rounded-md border border-solid border-zinc-800 bg-zinc-900 p-2 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
                     <CardList cards={commanders} parentDelete={removeAction} />
                 </div>
             )}

--- a/resources/js/Components/DeckModalContent.tsx
+++ b/resources/js/Components/DeckModalContent.tsx
@@ -285,6 +285,7 @@ const DeckModalContent = ({
         if (!isFormEdited) {
             console.log('Form has not been edited. Skipping submission.');
             closeForm();
+            callback?.();
             return;
         }
         if (creating) {

--- a/resources/js/Components/MTGCard.tsx
+++ b/resources/js/Components/MTGCard.tsx
@@ -37,7 +37,7 @@ const MTGCard = ({
             <div className="card-actions group absolute z-10 aspect-[2.5/3.5] w-full content-center">
                 {onDelete && (
                     <button
-                        className={`btn btn-primary transition-rotate absolute right-0 top-0 rounded-full border-none bg-black/50 p-1 opacity-100 duration-200 ease-in-out hover:bg-black group-hover:opacity-100 lg:opacity-0`}
+                        className={`btn btn-primary transition-rotate absolute right-0 top-0 rounded-full border-none bg-black/50 p-1 duration-200 ease-in-out hover:bg-black`}
                         onClick={onDelete}
                     >
                         <MdDeleteForever className="h-12 w-12 md:h-10 md:w-10 lg:h-6 lg:w-6" />

--- a/resources/js/Pages/Cards/Index.tsx
+++ b/resources/js/Pages/Cards/Index.tsx
@@ -52,7 +52,7 @@ export default function Cards({ cards, decks }: { cards: any; decks: Deck[] }) {
                 <div className="my-4">
                     <ButtonShelf buttons={buttons} />
                 </div>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-6">
                     {parsedCardsWithDeckRefs.length > 0 &&
                         parsedCardsWithDeckRefs && (
                             <CardList

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -151,7 +151,7 @@ const Show = ({ deck }: Props) => {
         return true;
     };
 
-    const renderErrors = () => {
+    const renderCardErrors = () => {
         if (!recentlySuccessful) {
             return (
                 <p>
@@ -259,8 +259,7 @@ const Show = ({ deck }: Props) => {
     return (
         <div className="container mx-auto flex pt-2">
             <div className="flex w-full grow flex-col items-center gap-4 py-4 pb-16">
-                {renderErrors()}
-                {isEditing ? (
+                {isEditing && (
                     <form
                         onSubmit={onSubmit}
                         className="flex w-full flex-col items-center gap-4"
@@ -279,16 +278,10 @@ const Show = ({ deck }: Props) => {
                             />
                         </div>
                     </form>
-                ) : (
-                    <div>
-                        {deck && deck.name && user.id === deck.user_id ? (
-                            <>{deck.name}</>
-                        ) : (
-                            <p className="text-zinc-500">
-                                No deck selected or no permission to edit
-                            </p>
-                        )}
-                    </div>
+                )}
+                <h2 className="text-lg font-semibold">Commanders</h2>
+                {errors.commanders && (
+                    <p className="text-red-500">{errors.commanders}</p>
                 )}
                 <div className="relative z-0 w-full pb-4">
                     <DeckCommanderSearch
@@ -302,6 +295,8 @@ const Show = ({ deck }: Props) => {
                     />
                 </div>
 
+                <h2 className="text-lg font-semibold">Cards</h2>
+                {errors.cards && <p className="text-red-500">{errors.cards}</p>}
                 {selectedCommanders.length > 0 && (
                     <div className="relative z-0 w-full pb-4">
                         <DeckCardSearch

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -111,23 +111,7 @@ const Show = ({ deck }: Props) => {
         setSelectedCards(uniqueOutput);
         setData('cards', uniqueOutput); // Update cards in the form state
     };
-
-    const _removeCard = (card: CardDataType) => {
-        if (!isFormEdited) setIsFormEdited(true);
-        const updatedCards = selectedCards.filter((c) => c.id !== card.id);
-        setSelectedCards(updatedCards);
-        setData('cards', updatedCards);
-    };
-
-    const _removeCommander = (card: CardDataType) => {
-        if (!isFormEdited) setIsFormEdited(true);
-        const updatedCommanders = selectedCommanders.filter(
-            (c) => c.id !== card.id,
-        );
-        setSelectedCommanders(updatedCommanders);
-        setData('commanders', updatedCommanders);
-    };
-
+    
     useEffect(() => {
         const allUniqueColorsFromCards = Array.from(
             new Set(selectedCards.flatMap((card) => card.colorIdentity)),
@@ -245,6 +229,14 @@ const Show = ({ deck }: Props) => {
 
     const handleCommanderDelete = (card: CardWithDecks | CardDataType) => {
         if (deck.commanders.length > 1) {
+            if (!isFormEdited) setIsFormEdited(true);
+
+            const updatedCommanders = selectedCommanders.filter(
+                (c) => c.id !== card.id,
+            );
+
+            setSelectedCommanders(updatedCommanders);
+
             updateDecks({
                 decks: [deck],
                 user_id: user.id,
@@ -255,6 +247,13 @@ const Show = ({ deck }: Props) => {
         }
     };
     const handleCardDelete = (card: CardWithDecks | CardDataType) => {
+
+        if (!isFormEdited) setIsFormEdited(true);
+
+        const updatedCards = selectedCards.filter((c) => c.id !== card.id);
+
+        setSelectedCards(updatedCards);
+
         updateDecks({
             decks: [deck],
             user_id: user.id,
@@ -301,7 +300,7 @@ const Show = ({ deck }: Props) => {
                         parentSetter={handleCommanderSelect}
                         commanders={selectedCommanders}
                         processing={processing}
-                        removeAction={_removeCommander}
+                        removeAction={handleCommanderDelete}
                         commanderColorIdentity={currentColorIdentity}
                         cardVisualization={true}
                     />
@@ -314,7 +313,7 @@ const Show = ({ deck }: Props) => {
                             parentSetter={handleCardSelect}
                             cards={selectedCards}
                             processing={processing}
-                            removeAction={_removeCard}
+                            removeAction={handleCardDelete}
                             colorValidation={selectedCommanders.length > 0}
                             cardVisualization={true}
                             commanderColorIdentity={currentColorIdentity}

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -174,7 +174,7 @@ const Show = ({ deck }: Props) => {
     };
 
     const handleCommanderDelete = (card: CardWithDecks | CardDataType) => {
-        if (deck.commanders.length > 1) {
+        if (selectedCommanders.length > 1) {
             if (!isFormEdited) setIsFormEdited(true);
 
             const updatedCommanders = selectedCommanders.filter(

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -1,11 +1,18 @@
 import CardList from '@/Components/CardList';
 import { useToast } from '@/Components/Toast/ToastContext';
-import { CardDataType, CardWithDecks, Deck as DeckProps } from '@/types/mtg';
+import { CardDataType, CardWithDecks ,Deck as DeckProps, mtgColorStrings } from '@/types/mtg';
+import { getColorIdentityFromCommanders } from '@/utilities/general';
+import { useForm, usePage } from '@inertiajs/react';
+import { FormEvent, useEffect, useState } from 'react';
+import Button from '../../../Components/Button';
+import Input from '../../../Components/Input';
+import DeckCardSearch from '../../../Components/DeckCardSearch';
+import DeckCommanderSearch from '../../../Components/DeckCommanderSearch';
+
 import updateDecks, {
     removeCard,
     removeCommander,
 } from '@/utilities/updateDecks';
-import { usePage } from '@inertiajs/react';
 
 type Props = {
     deck: DeckProps;
@@ -14,6 +21,280 @@ type Props = {
 const Show = ({ deck }: Props) => {
     const user = usePage().props.auth.user;
     const { openToast } = useToast();
+    const [isEditing, setIsEditing] = useState(true);
+    const [disableSubmitButton, setDisableSubmitButton] = useState(false);
+    const [selectedCards, setSelectedCards] = useState<CardDataType[]>(
+        deck?.cards || [],
+    );
+    const [selectedCommanders, setSelectedCommanders] = useState<
+        CardDataType[]
+    >(deck?.commanders || []);
+    const [isFormEdited, setIsFormEdited] = useState(false); // Track form edits
+    const [namedByUser, setNamedByUser] = useState(deck?.name ?? false); // Track if the deck is named by the user
+    const initialCommanderColorIdentity =
+        getColorIdentityFromCommanders(selectedCommanders);
+    const [currentColorIdentity, setCurrentColorIdentity] = useState<
+        mtgColorStrings[]
+    >(initialCommanderColorIdentity);
+
+    const {
+        data,
+        setData,
+        patch,
+        post,
+        processing,
+        clearErrors,
+        reset,
+        errors,
+        setError,
+        wasSuccessful,
+        recentlySuccessful,
+    } = useForm({
+        name: deck?.name || undefined,
+        user_id: user.id,
+        cards: selectedCards,
+        commanders: selectedCommanders,
+    });
+
+    const isValidDeck = (deck: any): deck is Deck => {
+        return (
+            deck &&
+            typeof deck.id === 'number' &&
+            typeof deck.name === 'string' &&
+            typeof deck.created_at === 'string' &&
+            typeof deck.updated_at === 'string'
+        );
+    };
+
+    useEffect(() => {
+        const newCommanderColorIdentity =
+            getColorIdentityFromCommanders(selectedCommanders);
+        setCurrentColorIdentity(newCommanderColorIdentity);
+    }, [selectedCommanders]);
+
+    const handleCommanderSelect = (results: CardDataType[] | []) => {
+        if (!isFormEdited) setIsFormEdited(true);
+        if (results === undefined || results.length == 0) return;
+
+        let uniqueOutput: CardDataType[] = [];
+
+        if (selectedCommanders.length > 0) {
+            uniqueOutput = [...selectedCommanders, ...results].filter(
+                (item, index, self) =>
+                    index === self.findIndex((t) => t.id === item.id),
+            );
+        } else {
+            uniqueOutput = [...results];
+        }
+        setSelectedCommanders(uniqueOutput); // Update selectedCommanders instead of selectedCards
+        setData('commanders', uniqueOutput); // Update commanders in the form state
+    };
+
+    const handleCardSelect = (results: CardDataType[] | []) => {
+        if (!isFormEdited) setIsFormEdited(true);
+        if (results === undefined || results.length == 0) return;
+
+        let uniqueOutput: CardDataType[] = [];
+
+        if (selectedCards.length > 0) {
+            uniqueOutput = [...selectedCards, ...results].filter(
+                (item, index, self) =>
+                    index === self.findIndex((t) => t.id === item.id),
+            );
+        } else {
+            uniqueOutput = [...results];
+        }
+        setSelectedCards(uniqueOutput);
+        setData('cards', uniqueOutput); // Update cards in the form state
+    };
+
+    const _removeCard = (card: CardDataType) => {
+        if (!isFormEdited) setIsFormEdited(true);
+        const updatedCards = selectedCards.filter((c) => c.id !== card.id);
+        setSelectedCards(updatedCards);
+        setData('cards', updatedCards);
+    };
+
+    const _removeCommander = (card: CardDataType) => {
+        if (!isFormEdited) setIsFormEdited(true);
+        const updatedCommanders = selectedCommanders.filter(
+            (c) => c.id !== card.id,
+        );
+        setSelectedCommanders(updatedCommanders);
+        setData('commanders', updatedCommanders);
+    };
+
+    useEffect(() => {
+        const allUniqueColorsFromCards = Array.from(
+            new Set(selectedCards.flatMap((card) => card.colorIdentity)),
+        );
+        const areAnyCardColorsInvalid = allUniqueColorsFromCards.some(
+            (color) => !currentColorIdentity.includes(color),
+        );
+        const invalidColorIdentity =
+            allUniqueColorsFromCards.length > 0
+                ? areAnyCardColorsInvalid
+                : false;
+
+        if (
+            invalidColorIdentity &&
+            (isFormEdited || isEditing) &&
+            selectedCards.length > 0
+        ) {
+            setError(
+                'cards',
+                "Selected cards do not match the deck's color identity",
+            );
+        } else {
+            clearErrors('cards');
+        }
+        nameUnNamedDeckWithCommanders();
+    }, [selectedCards, currentColorIdentity, isEditing]);
+
+    useEffect(() => {
+        if (errors.cards || errors.commanders) {
+            setDisableSubmitButton(true);
+        } else {
+            setDisableSubmitButton(false);
+        }
+    }, [errors]);
+
+    const validate = () => {
+        if (data.commanders.length === 0) {
+            setError('commanders', 'At least one commander is required');
+            return false;
+        }
+        if (data.commanders.length > 3) {
+            setError('commanders', 'No more than three commanders are allowed');
+            return false;
+        }
+
+        clearErrors(); // Clear previous errors
+
+        return true;
+    };
+
+    const renderErrors = () => {
+        if (!recentlySuccessful) {
+            return (
+                <p>
+                    {errors.cards && (
+                        <span className="text-red-500">{errors.cards}</span>
+                    )}{' '}
+                    {errors.commanders && (
+                        <span className="text-red-500">
+                            {errors.commanders}
+                        </span>
+                    )}
+                </p>
+            );
+        }
+        return null;
+    };
+
+    const closeForm = () => {
+        reset();
+    };
+
+    const nameUnNamedDeckWithCommanders = () => {
+        if (data.commanders.length > 0 && !namedByUser) {
+            const commanderNames = data.commanders
+                .map((commander: CardDataType) => commander.name)
+                .join(' // ');
+
+            const isDeckNamedAfterCommanders = data.name === commanderNames;
+
+            if (!data.name) {
+                setData('name', commanderNames);
+            } else if (data.name && !isDeckNamedAfterCommanders) {
+                setData('name', commanderNames);
+            }
+        }
+    };
+
+    const createDeck = (callback?: () => void) => {
+        post(route('decks.store'), {
+            data,
+            preserveScroll: true, // Prevents the page from scrolling to the top
+            onSuccess: (response) => {
+                if (isValidDeck(response.props.updatedDeck)) {
+                    if (onDeckUpdated) {
+                        onDeckUpdated(response.props.updatedDeck);
+                        openToast?.(
+                            `Deck "${response.props.updatedDeck.name}" created`,
+                            'info',
+                        );
+                    }
+                    if (callback) {
+                        callback();
+                    }
+                } else {
+                    console.warn(
+                        'Invalid or empty updatedDeck:',
+                        response.props.updatedDeck,
+                    );
+                }
+                closeForm();
+            },
+            onError: (errors) => {
+                console.error(errors);
+            },
+        });
+    };
+
+    const updateDeck = (callback?: () => void) => {
+        patch(route('decks.update', deck?.id), {
+            data,
+            preserveScroll: true,
+            onSuccess: (response) => {
+                if (isValidDeck(response.props.updatedDeck)) {
+                    if (onDeckUpdated) {
+                        onDeckUpdated(response.props.updatedDeck);
+                    }
+                    openToast?.(
+                        `Deck "${response.props.updatedDeck.name}" updated`,
+                        'info',
+                    );
+                    if (callback) {
+                        callback();
+                    }
+                } else {
+                    console.warn(
+                        'Invalid or empty updatedDeck:',
+                        response.props.updatedDeck,
+                    );
+                }
+                closeForm();
+            },
+            onError: (errors) => {
+                console.error(errors);
+            },
+        });
+    };
+
+    const onSubmit = async (e: FormEvent, callback?: () => void) => {
+        e.preventDefault();
+        await validate();
+        if (errors.cards || errors.commanders) {
+            console.log('Form has errors. Skipping submission.');
+            return;
+        }
+        if (!isFormEdited) {
+            console.log('Form has not been edited. Skipping submission.');
+            closeForm();
+            return;
+        }
+        if (creating) {
+            createDeck(callback);
+        } else if (!creating) {
+            updateDeck(callback);
+        }
+    };
+
+
+
+    // ------------------------
+
     const handleCommanderDelete = (card: CardWithDecks | CardDataType) => {
         if (deck.commanders.length > 1) {
             updateDecks({
@@ -33,8 +314,108 @@ const Show = ({ deck }: Props) => {
         });
     };
     return (
+        <div>
+            <div className="flex h-full pt-2">
+            <div className="flex w-full grow flex-col items-center gap-4 py-4">
+                {renderErrors()}
+                {isEditing ? (
+                    <form
+                        onSubmit={onSubmit}
+                        className="flex w-full flex-col items-center gap-4"
+                    >
+                        <div className="relative flex w-full flex-wrap">
+                            <Input
+                                type="text"
+                                value={data.name || ''} // Ensure the input is always controlled
+                                placeholder="Name Your Deck"
+                                className="block w-full rounded-lg border border-zinc-300 bg-zinc-50 p-4 ps-10 text-sm text-zinc-900 focus:border-zinc-500 focus:ring-blue-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-white dark:placeholder-zinc-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+                                onChange={(e) => {
+                                    if (!isFormEdited) setIsFormEdited(true);
+                                    if (!namedByUser) setNamedByUser(true);
+                                    setData('name', e.target.value);
+                                }}
+                            />
+                        </div>
+                    </form>
+                ) : (
+                    <div>
+                        {deck && deck.name && user.id === deck.user_id ? (
+                            <>{deck.name}</>
+                        ) : (
+                            <p className="text-zinc-500">
+                                No deck selected or no permission to edit
+                            </p>
+                        )}
+                    </div>
+                )}
+                <div className="relative z-0 w-full pb-4">
+                    <DeckCommanderSearch
+                        isSearching={isEditing}
+                        parentSetter={handleCommanderSelect}
+                        commanders={selectedCommanders}
+                        processing={processing}
+                        removeAction={_removeCommander}
+                        commanderColorIdentity={currentColorIdentity}
+                    />
+                </div>
+
+                {selectedCommanders.length > 0 && (
+                    <div className="relative z-0 w-full pb-4">
+                        <DeckCardSearch
+                            isSearching={isEditing}
+                            parentSetter={handleCardSelect}
+                            cards={selectedCards}
+                            processing={processing}
+                            removeAction={_removeCard}
+                            colorValidation={selectedCommanders.length > 0}
+                            commanderColorIdentity={currentColorIdentity}
+                        />
+                    </div>
+                )}
+
+                <div className="relative shrink-0">
+                        <div className="flex items-center justify-center gap-2">
+                            <Button
+                                onClick={() => setIsEditing(!isEditing)}
+                                disabled={processing}
+                                className="border border-solid border-black bg-zinc-900 px-3 py-2"
+                            >
+                                {!isEditing ? 'edit' : 'cancel'}
+                            </Button>
+                            {isEditing && (
+                                <Button
+                                    onClick={(e) => {
+                                        e.preventDefault(); // Prevent default button behavior
+                                        onSubmit(e); // Trigger the form submission
+                                    }}
+                                    disabled={processing || disableSubmitButton}
+                                    className="border border-solid border-black bg-zinc-900 px-3 py-2"
+                                >
+                                    Save
+                                </Button>
+                            )}
+                            <Button
+                                disabled={processing || disableSubmitButton}
+                                className="border border-solid border-black bg-zinc-900 px-3 py-2"
+                                onClick={(e) => {
+                                    // TO DO : refactor to use link
+                                    if (isEditing) {
+                                        e.preventDefault(); // Prevent default navigation
+                                        onSubmit(e, () => {
+                                            window.location.href = `/decks/${deck?.id}`; // Navigate to the href
+                                        }); // Wait for onSubmit to resolve
+                                    } else {
+                                        window.location.href = `/decks/${deck?.id}`; // Navigate to the href
+                                    }
+                                }}
+                            >
+                                deck details
+                            </Button>
+                        </div>
+                </div>
+            </div>
+        </div>
         <div className="container mx-auto px-3 py-4">
-            <h2 className="text-lg font-semibold">Commanders</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
                 <CardList
                     cards={deck.commanders}
@@ -50,6 +431,8 @@ const Show = ({ deck }: Props) => {
                 />
             </div>
         </div>
+        </div>
+        
     );
 };
 

--- a/resources/js/Pages/Decks/Views/Show.tsx
+++ b/resources/js/Pages/Decks/Views/Show.tsx
@@ -111,7 +111,7 @@ const Show = ({ deck }: Props) => {
         setSelectedCards(uniqueOutput);
         setData('cards', uniqueOutput); // Update cards in the form state
     };
-    
+
     useEffect(() => {
         const allUniqueColorsFromCards = Array.from(
             new Set(selectedCards.flatMap((card) => card.colorIdentity)),
@@ -247,7 +247,6 @@ const Show = ({ deck }: Props) => {
         }
     };
     const handleCardDelete = (card: CardWithDecks | CardDataType) => {
-
         if (!isFormEdited) setIsFormEdited(true);
 
         const updatedCards = selectedCards.filter((c) => c.id !== card.id);
@@ -262,7 +261,7 @@ const Show = ({ deck }: Props) => {
     };
     return (
         <div className="container mx-auto flex pt-2">
-            <div className="flex w-full grow flex-col items-center gap-4 py-4">
+            <div className="flex w-full grow flex-col items-center gap-4 py-4 pb-16">
                 {renderErrors()}
                 {isEditing ? (
                     <form
@@ -321,15 +320,8 @@ const Show = ({ deck }: Props) => {
                     </div>
                 )}
 
-                <div className="relative shrink-0">
+                <div className="fixed bottom-0 z-10 w-full shrink-0 bg-zinc-900 py-2">
                     <div className="flex items-center justify-center gap-2">
-                        <Button
-                            onClick={() => setIsEditing(!isEditing)}
-                            disabled={processing}
-                            className="border border-solid border-black bg-zinc-900 px-3 py-2"
-                        >
-                            {!isEditing ? 'edit' : 'cancel'}
-                        </Button>
                         {isEditing && (
                             <Button
                                 onClick={(e) => {
@@ -339,9 +331,16 @@ const Show = ({ deck }: Props) => {
                                 disabled={processing || disableSubmitButton}
                                 className="border border-solid border-black bg-zinc-900 px-3 py-2"
                             >
-                                Save
+                                Save Deck Changes
                             </Button>
                         )}
+                        <Button
+                            onClick={() => setIsEditing(!isEditing)}
+                            disabled={processing}
+                            className="border border-solid border-black bg-zinc-900 px-3 py-2"
+                        >
+                            {!isEditing ? 'Edit Deck' : 'Cancel'}
+                        </Button>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Founders.tsx
+++ b/resources/js/Pages/Founders.tsx
@@ -4,7 +4,6 @@ export default function Founder() {
             <h1>Founders</h1>
             <ul>
                 <li>Nick Zou</li>
-                <li>Jordan Armstrong</li>
                 <li>Adrian Davila-Zuniga</li>
             </ul>
         </main>

--- a/resources/js/types/mtg.d.ts
+++ b/resources/js/types/mtg.d.ts
@@ -23,7 +23,7 @@ export interface CardDataType {
     isInvalidColor?: boolean;
 }
 
-export type CardWithDecks = CardDataType & {
+export type CardWithDecksType = CardDataType & {
     decks: Deck[] | undefined;
 };
 

--- a/resources/js/types/mtg.d.ts
+++ b/resources/js/types/mtg.d.ts
@@ -20,6 +20,7 @@ export interface CardDataType {
     power?: string;
     toughness?: string;
     backCardData?: CardDataType;
+    isInvalidColor?: boolean;
 }
 
 export type CardWithDecks = CardDataType & {

--- a/resources/js/utilities/updateDecks.ts
+++ b/resources/js/utilities/updateDecks.ts
@@ -28,15 +28,16 @@ type UpdateDecks = {
     user_id: number;
     cards?: CardDataType[] | undefined;
     commanders?: CardDataType[] | undefined;
+    name?: string;
     parentSetter?: Dispatch<SetStateAction<boolean>>;
 };
 
-const updateDecks = (args: UpdateDecks) => {
+const updateDecks = (args: UpdateDecks, callBack?: () => void) => {
     const { decks, user_id, cards, commanders, parentSetter } = args;
 
     const updatedDecks = decks.map((deck) => ({
         id: deck.id,
-        name: deck.name,
+        name: !!args.name ? args.name : deck.name,
         cards: !!cards ? cards : deck.cards,
         commanders: !!commanders ? commanders : deck.commanders,
     }));
@@ -46,11 +47,15 @@ const updateDecks = (args: UpdateDecks) => {
         { user_id: user_id, decks: updatedDecks },
         {
             preserveState: true,
+            preserveScroll: true,
             only: [],
             onSuccess: () => {
                 console.log(`Card updated to decks`);
                 if (parentSetter) {
                     parentSetter(true);
+                }
+                if (callBack) {
+                    callBack();
                 }
             },
             onError: (errors) => {

--- a/resources/js/utilities/updateDecks.ts
+++ b/resources/js/utilities/updateDecks.ts
@@ -37,7 +37,7 @@ const updateDecks = (args: UpdateDecks, callBack?: () => void) => {
 
     const updatedDecks = decks.map((deck) => ({
         id: deck.id,
-        name: !!args.name ? args.name : deck.name,
+        name: args.name || deck.name,
         cards: !!cards ? cards : deck.cards,
         commanders: !!commanders ? commanders : deck.commanders,
     }));


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of your changes -->

- refactored deck/show to use same layout / logic as `DeckContentModal`
- added support for card visualization for `DeckCommanderSearch` and `CardCommanderSearch` by using `CardList`
- added error visualization to `cardlist`
- changed behaviour of remove card button
- changed grid sizing for card display on XL
- changed template


## How to Test
<!-- Describe what testing you've done -->
 - [x] deck details page can toggle between edit mode and view mode
 - [x] you cannot remove the last commander and toast with error message appears when trying to do so
 - [x] you can remove an extra commander
 - [x] you can remove cards
 - [x] when removing a commander and color identity changes - invalid cards are highlighted and submit button is disabled
 - [x] delete btn on cards appears when in editing mode
 - [x] delete btn on cards is always present if card is invalid color
 - [x] invalid color cards are highlighted
 - [x] you can edit name of deck
 - [x] autocomplete for cards filters based on colour identity of deck
 - [x] autocomplete for commanders filters to only partner compatible cards after 1st commander is inputed


## Screenshots (if applicable)
<!-- Add screenshots here if there are UI changes -->
![Screenshot 2025-05-23 at 12 12 15 PM](https://github.com/user-attachments/assets/615fbfad-57d6-48ae-b55a-3f81829c81b9)
![Screenshot 2025-05-23 at 12 12 29 PM](https://github.com/user-attachments/assets/d26598d5-8b1e-463f-9e49-9035a1b41399)
![Screenshot 2025-05-23 at 12 13 08 PM](https://github.com/user-attachments/assets/11674d63-904f-457e-abba-5f7893d7bd40)


## To Do (post - MVP)
 - refactor to allow deck name edit to appear in page header
 - styling tweaks to delete button
 - discuss how best to display edit button
 - center commanders

